### PR TITLE
Fixed SyntaxError caused by odd 'r' characters

### DIFF
--- a/scapy/volatile.py
+++ b/scapy/volatile.py
@@ -594,9 +594,9 @@ class RandSingString(RandSingularity):
                          b"LST:",
                          b"NUL:",
                          b"CON:",
-                         rb"C:\CON\CON",
-                         rb"C:\boot.ini",
-                         rb"\\myserver\share",
+                         b"C:\CON\CON",
+                         b"C:\boot.ini",
+                         b"\\myserver\share",
                          b"foo.exe:",
                          b"foo.exe\\", ]
                              


### PR DESCRIPTION
Removed the 'r' character from the beginning of lines 597-599 causing a "SyntaxError: invalid syntax" when installing with pip-3.2 on Debian Wheezy. This error also prevents a `from scapy import all` call.