### PR TITLE
Add missing import in p0f module

### DIFF
--- a/scapy/modules/p0f.py
+++ b/scapy/modules/p0f.py
@@ -9,6 +9,7 @@ Clone of p0f passive OS fingerprinting
 
 from scapy.data import KnowledgeBase
 from scapy.config import conf
+from scapy.error import warning
 from scapy.layers.inet import IP, TCP, TCPOptions
 from scapy.packet import NoPayload
 


### PR DESCRIPTION
The p0f module calls the `warning` function, without actually importing it.