### PR TITLE
sendpfast improvements

### DIFF
--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -533,13 +533,16 @@ def wrpcap(filename, pkt, *args, **kargs):
 gz: set to 1 to save a gzipped capture
 linktype: force linktype value
 endianness: "<" or ">", force endianness"""
-    PcapWriter(filename, *args, **kargs).write(pkt)
+    with PcapWriter(filename, *args, **kargs) as pcap:
+        pcap.write(pkt)
 
 @conf.commands.register
 def rdpcap(filename, count=-1):
     """Read a pcap file and return a packet list
 count: read only <count> packets"""
-    return PcapReader(filename).read_all(count=count)
+    with PcapReader(filename) as pcap:
+        pkts = pcap.read_all(count=count)
+    return pkts
 
 class RawPcapReader:
     """A stateful pcap reader. Each packet is returned as bytes"""


### PR DESCRIPTION
* Fix some file descriptor leaks causing warnings when calling `sendpfast`
* Add a verbose parameter to `sendpfast` to optionally discard tcpreplay output

See commit messages.