### PR TITLE
IKEv2_payload_Transform's transform_id is a MultiEnumField now

### DIFF
--- a/scapy/contrib/ikev2.py
+++ b/scapy/contrib/ikev2.py
@@ -98,7 +98,7 @@ for n in IKEv2TransformTypes:
     tmp = {}
     for e in val[1]:
         tmp[val[1][e]] = e
-    IKEv2TransformNum[val[0]] = (n,tmp, val[2])
+    IKEv2TransformNum[val[0]] = tmp
 
 IKEv2Transforms = {}
 for n in IKEv2TransformTypes:
@@ -176,25 +176,6 @@ class IKEv2_Key_Length_Attribute(IntField):
 		
 	def h2i(self, pkt, x):
 		return IntField.h2i(self, pkt, struct.pack("!I", 0x800E0000 | int(x, 0)))
-
-
-class IKEv2_Transform_ID(ShortField):
-	def i2h(self, pkt, x):
-		if pkt == None:
-			return None
-		else:
-			map = IKEv2TransformNum[pkt.transform_type][1]
-			return map[x]
-		
-	def h2i(self, pkt, x):
-		if pkt == None:
-			return None
-		else:
-			map = IKEv2TransformNum[pkt.transform_type][1]
-			for k in keys(map):
-				if map[k] == x:
-					return k
-			return None
 		
 class IKEv2_payload_Transform(IKEv2_class):
     name = "IKE Transform"
@@ -204,7 +185,7 @@ class IKEv2_payload_Transform(IKEv2_class):
         ShortField("length",8),
         ByteEnumField("transform_type",None,IKEv2Transforms),
         ByteField("res2",0),
-        IKEv2_Transform_ID("transform_id", 0),
+        MultiEnumField("transform_id",None,IKEv2TransformNum,depends_on=lambda pkt:pkt.transform_type,fmt="H"),
         ConditionalField(IKEv2_Key_Length_Attribute("key_length"), lambda pkt: pkt.length > 8),
     ]
             


### PR DESCRIPTION
If I execute the following commands in the scapy command line:

\>>> from scapy.contrib.ikev2 import *
\>>> IKEv2_payload_Transform(transform_type = 'Encryption', transform_id = 'AES-CBC')

I get the following exception:

Traceback (most recent call last):
  File "/usr/lib/python3.4/code.py", line 90, in runcode
    exec(code, self.locals)
  File "<console>", line 1, in <module>
  File "/usr/local/lib/python3.4/dist-packages/scapy/base_classes.py", line 199, in __call__
    i.__init__(*args, **kargs)
  File "/usr/local/lib/python3.4/dist-packages/scapy/packet.py", line 91, in __init__
    self.fields[f] = self.get_field(f).any2i(self,fields[f])
  File "/usr/local/lib/python3.4/dist-packages/scapy/fields.py", line 73, in any2i
    return self.h2i(pkt, x)
  File "/usr/local/lib/python3.4/dist-packages/scapy/contrib/ikev2.py", line 194, in h2i
    for k in keys(map):
NameError: name 'keys' is not defined

The reason is that IKEv2_Transform_ID accesses pkt.transform_type and thus requires transform_type to be set before transform_id. This, however, is not guaranteed, because these two constructor arguments to IKEv2_payload_Transform are passed in a python dictionary, and the order in which elements are stored in a dictionary is not defined but implementation dependent.

As far as I can see, the whole task of IKEv2_Transform_ID is to make the transform ID an enum whose set of possible values depends on the transform_type. For this purpose, scapy already provides the class MultiEnumField, so I propose to use just that to fix this issue.