### PR TITLE
Correctly calculate overload_fields of IKEv2 payload classes

### DIFF
--- a/scapy/contrib/ikev2.py
+++ b/scapy/contrib/ikev2.py
@@ -292,7 +292,6 @@ class IKEv2_payload(IKEv2_class):
 
 class IKEv2_payload_VendorID(IKEv2_class):
     name = "IKEv2 Vendor ID"
-    overload_fields = { IKEv2: { "next_payload":43 }}
     fields_desc = [
         ByteEnumField("next_payload",None,IKEv2_payload_type),
         ByteField("res",0),
@@ -302,7 +301,6 @@ class IKEv2_payload_VendorID(IKEv2_class):
 
 class IKEv2_payload_Delete(IKEv2_class):
     name = "IKEv2 Vendor ID"
-    overload_fields = { IKEv2: { "next_payload":42 }}
     fields_desc = [
         ByteEnumField("next_payload",None,IKEv2_payload_type),
         ByteField("res",0),
@@ -312,7 +310,6 @@ class IKEv2_payload_Delete(IKEv2_class):
 
 class IKEv2_payload_SA(IKEv2_class):
     name = "IKEv2 SA"
-    overload_fields = { IKEv2: { "next_payload":33 }}
     fields_desc = [
         ByteEnumField("next_payload",None,IKEv2_payload_type),
         ByteField("res",0),
@@ -322,7 +319,6 @@ class IKEv2_payload_SA(IKEv2_class):
 
 class IKEv2_payload_Nonce(IKEv2_class):
     name = "IKEv2 Nonce"
-    overload_fields = { IKEv2: { "next_payload":40 }}
     fields_desc = [
         ByteEnumField("next_payload",None,IKEv2_payload_type),
         ByteField("res",0),
@@ -332,7 +328,6 @@ class IKEv2_payload_Nonce(IKEv2_class):
 
 class IKEv2_payload_Notify(IKEv2_class):
     name = "IKEv2 Notify"
-    overload_fields = { IKEv2: { "next_payload":41 }}
     fields_desc = [
         ByteEnumField("next_payload",None,IKEv2_payload_type),
         ByteField("res",0),
@@ -346,7 +341,6 @@ class IKEv2_payload_Notify(IKEv2_class):
 
 class IKEv2_payload_KE(IKEv2_class):
     name = "IKEv2 Key Exchange"
-    overload_fields = { IKEv2: { "next_payload":34 }}
     fields_desc = [
         ByteEnumField("next_payload",None,IKEv2_payload_type),
         ByteField("res",0),
@@ -358,7 +352,6 @@ class IKEv2_payload_KE(IKEv2_class):
 
 class IKEv2_payload_IDi(IKEv2_class):
     name = "IKEv2 Identification - Initiator"
-    overload_fields = { IKEv2: { "next_payload":35 }}
     fields_desc = [
         ByteEnumField("next_payload",None,IKEv2_payload_type),
         ByteField("res",0),
@@ -372,7 +365,6 @@ class IKEv2_payload_IDi(IKEv2_class):
 
 class IKEv2_payload_IDr(IKEv2_class):
     name = "IKEv2 Identification - Responder"
-    overload_fields = { IKEv2: { "next_payload":36 }}
     fields_desc = [
         ByteEnumField("next_payload",None,IKEv2_payload_type),
         ByteField("res",0),
@@ -388,7 +380,6 @@ class IKEv2_payload_IDr(IKEv2_class):
 
 class IKEv2_payload_Encrypted(IKEv2_class):
     name = "IKEv2 Encrypted and Authenticated"
-    overload_fields = { IKEv2: { "next_payload":46 }}
     fields_desc = [
         ByteEnumField("next_payload",None,IKEv2_payload_type),
         ByteField("res",0),
@@ -396,17 +387,20 @@ class IKEv2_payload_Encrypted(IKEv2_class):
         StrLenField("load","",length_from=lambda x:x.length-4),
         ]
 
-
-
-IKEv2_payload_type_overload = {}
+IKEv2_payload_classes = {}
 for i in range(len(IKEv2_payload_type)):
     name = "IKEv2_payload_%s" % IKEv2_payload_type[i]
     if name in globals():
-        IKEv2_payload_type_overload[globals()[name]] = {"next_payload":i}
+        IKEv2_payload_classes[globals()[name]] = i
+
+for i in IKEv2_payload_classes:
+    i.overload_fields = {IKEv2 : {"next_payload" : IKEv2_payload_classes[i]}}
+    for j in IKEv2_payload_classes:
+        i.overload_fields[j] = {"next_payload" : IKEv2_payload_classes[i]}
 
 del(i)
+del(j)
 del(name)
-IKEv2_class.overload_fields = IKEv2_payload_type_overload.copy()
 
 split_layers(UDP, ISAKMP, sport=500)
 split_layers(UDP, ISAKMP, dport=500)

--- a/test/ipsec.uts
+++ b/test/ipsec.uts
@@ -766,6 +766,20 @@ assert(p.sport == 500)
 assert(p.dport == 500)
 
 #######################################
+= IKEv2 - next_payload
+
+assert(IKEv2(bytes(IKEv2()/IKEv2_payload_Transform())).next_payload == 3)
+assert(IKEv2(bytes(IKEv2()/IKEv2_payload_SA()       )).next_payload == 33)
+assert(IKEv2(bytes(IKEv2()/IKEv2_payload_KE()       )).next_payload == 34)
+assert(IKEv2(bytes(IKEv2()/IKEv2_payload_IDi()      )).next_payload == 35)
+assert(IKEv2(bytes(IKEv2()/IKEv2_payload_IDr()      )).next_payload == 36)
+assert(IKEv2(bytes(IKEv2()/IKEv2_payload_Nonce()    )).next_payload == 40)
+assert(IKEv2(bytes(IKEv2()/IKEv2_payload_Notify()   )).next_payload == 41)
+assert(IKEv2(bytes(IKEv2()/IKEv2_payload_Delete()   )).next_payload == 42)
+assert(IKEv2(bytes(IKEv2()/IKEv2_payload_VendorID() )).next_payload == 43)
+assert(IKEv2(bytes(IKEv2()/IKEv2_payload_Encrypted())).next_payload == 46)
+
+#######################################
 = IKEv2_payload_Transform
 
 p = IKEv2_payload_Transform(bytes(IKEv2_payload_Transform()))
@@ -819,3 +833,31 @@ assert(IKEv2_payload_Notify(type = 'INVALID_IKE_SPI').type == 4)
 assert(IKEv2_payload_Notify(type = 'FAILED_CP_REQUIRED').type == 37)
 assert(IKEv2_payload_Notify(type = 'NAT_DETECTION_SOURCE_IP').type == 16388)
 assert(IKEv2_payload_Notify(type = 'NAT_DETECTION_DESTINATION_IP').type == 16389)
+
+#######################################
+= IKEv2_payload_Notify - Set next_payload on previous payload
+
+assert(IKEv2_payload_Transform(bytes(IKEv2_payload_Transform()/IKEv2_payload_Notify())).next_payload == 41)
+assert(IKEv2_payload_SA       (bytes(IKEv2_payload_SA()       /IKEv2_payload_Notify())).next_payload == 41)
+assert(IKEv2_payload_KE       (bytes(IKEv2_payload_KE()       /IKEv2_payload_Notify())).next_payload == 41)
+assert(IKEv2_payload_IDi      (bytes(IKEv2_payload_IDi()      /IKEv2_payload_Notify())).next_payload == 41)
+assert(IKEv2_payload_IDr      (bytes(IKEv2_payload_IDr()      /IKEv2_payload_Notify())).next_payload == 41)
+assert(IKEv2_payload_Nonce    (bytes(IKEv2_payload_Nonce()    /IKEv2_payload_Notify())).next_payload == 41)
+assert(IKEv2_payload_Notify   (bytes(IKEv2_payload_Notify()   /IKEv2_payload_Notify())).next_payload == 41)
+assert(IKEv2_payload_Delete   (bytes(IKEv2_payload_Delete()   /IKEv2_payload_Notify())).next_payload == 41)
+assert(IKEv2_payload_VendorID (bytes(IKEv2_payload_VendorID() /IKEv2_payload_Notify())).next_payload == 41)
+assert(IKEv2_payload_Encrypted(bytes(IKEv2_payload_Encrypted()/IKEv2_payload_Notify())).next_payload == 41)
+
+#######################################
+= IKEv2_payload_Notify - Set next_payload for next payload
+
+assert(IKEv2_payload_Notify(bytes(IKEv2_payload_Notify()/IKEv2_payload_Transform())).next_payload == 3)
+assert(IKEv2_payload_Notify(bytes(IKEv2_payload_Notify()/IKEv2_payload_SA()       )).next_payload == 33)
+assert(IKEv2_payload_Notify(bytes(IKEv2_payload_Notify()/IKEv2_payload_KE()       )).next_payload == 34)
+assert(IKEv2_payload_Notify(bytes(IKEv2_payload_Notify()/IKEv2_payload_IDi()      )).next_payload == 35)
+assert(IKEv2_payload_Notify(bytes(IKEv2_payload_Notify()/IKEv2_payload_IDr()      )).next_payload == 36)
+assert(IKEv2_payload_Notify(bytes(IKEv2_payload_Notify()/IKEv2_payload_Nonce()    )).next_payload == 40)
+assert(IKEv2_payload_Notify(bytes(IKEv2_payload_Notify()/IKEv2_payload_Notify()   )).next_payload == 41)
+assert(IKEv2_payload_Notify(bytes(IKEv2_payload_Notify()/IKEv2_payload_Delete()   )).next_payload == 42)
+assert(IKEv2_payload_Notify(bytes(IKEv2_payload_Notify()/IKEv2_payload_VendorID() )).next_payload == 43)
+assert(IKEv2_payload_Notify(bytes(IKEv2_payload_Notify()/IKEv2_payload_Encrypted())).next_payload == 46)


### PR DESCRIPTION
This change is more complicated, so I think it deserves a pull request on it's own.

In IKEv2, the IKEv2 header and all payload headers contain a field next_payload that contains the number of the next payload in the list or 0 for the last payload. In scapy, this field should be set automatically by using the overload_fields. Since scapy uses a different class for each payload type, the overload_fields variable of every payload must contain an entry for every supported payload type and one extra entry for the IKEv2 header itself. Since these lists are quite large and monotonous, they should be calculated automatically.

ikev2.py already contains some code to calculate overload_fields, but its flawed:
- If a payload with number q follows a payload with number p, q should set p.next_payload to q, but the calculated overload_fields sets it to p instead, so every payload specifies its own type as next payload instead of the type of the next payload.
- Only few payloads use the inherited overload_fields variable. Most payloads provide their own instead, but this refers to the IKEv2 header only, so they correctly set the next_payload field of the IKEv2 header if they are the first payload in the packet, but they fail to update any previous payload.

The new code calculates different overload_fields for each payload, where all overload_fields contain the same keys (all payloads plus the IKEv2 header), but differ in the mapped value, which is the corresponding type number.
