### PR TITLE
If we do need those options in the sub class, delete them we will have a problem

### DIFF
--- a/scapy/ansmachine.py
+++ b/scapy/ansmachine.py
@@ -73,8 +73,8 @@ class AnsweringMachine(object):
                 sniffopt[k] = kargs[k]
             if k in self.send_options_list:
                 sendopt[k] = kargs[k]
-            if k in self.sniff_options_list+self.send_options_list:
-                del(kargs[k])
+            #if k in self.sniff_options_list+self.send_options_list:
+            #    del(kargs[k])
         if mode != 2 or kargs:
             if mode == 1:
                 self.optam0 = kargs


### PR DESCRIPTION

See the DHCPv6_am, in the parse_options method, in there we need to know
the interface information to compute the source ip address

