### PR TITLE
Fix TypeError in CharEnumField

### DIFF
--- a/scapy/fields.py
+++ b/scapy/fields.py
@@ -772,7 +772,7 @@ class EnumField(Field):
 class CharEnumField(EnumField):
     def __init__(self, name, default, enum, fmt = "1s"):
         EnumField.__init__(self, name, default, enum, fmt)
-        k = self.i2s.keys()
+        k = list(self.i2s.keys())
         if k and len(k[0]) != 1:
             self.i2s,self.s2i = self.s2i,self.i2s
     def any2i_one(self, pkt, x):


### PR DESCRIPTION
Converts the dict_keys object to a list before attempting to index into it.
Fixes issue #83

It turns out that the minimal test program I used fails now on a different `TypeError` now, but that's consistent with the (incorrect) behavior of the python2 scapy. (The `EnumField` constructor tries to be overly clever and mistakenly inverts the enum dictionary, thinking that the character values are meant to be the human readable strings, even though a `CharEnumField`'s internal representation is a character value).

Using an enum mapping character values to strings works fine after this change.