### PR TITLE
Issue #99 - RandNum & int

### DIFF
--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -7,10 +7,10 @@
 Packet class. Binding mechanism. fuzz() method.
 """
 
-import time,itertools,os
+import time,itertools,os,random
 import sys,traceback
 import copy
-from .fields import StrField,ConditionalField,Emph,PacketListField
+from .fields import StrField,ConditionalField,Emph,PacketListField,FlagsField
 from .config import conf
 from .base_classes import BasePacket,Gen,SetGen,Packet_metaclass,NewDefaultValues
 from .volatile import VolatileValue
@@ -1288,6 +1288,9 @@ def fuzz(p, _inplace=0):
                 for r in getattr(q, f.name):
                     print("fuzzing", repr(r))
                     fuzz(r, _inplace=1)
+            elif isinstance(f, FlagsField):
+                rnd = random.randint(0, (2 ^ f.size) - 1)
+                q.default_fields[f.name] = rnd
             elif f.default is not None:
                 rnd = f.randval()
                 if rnd is not None:

--- a/test/flag_field_fuzzing_tester.py
+++ b/test/flag_field_fuzzing_tester.py
@@ -1,0 +1,66 @@
+## This file tests the changes made to the fuzz function that
+## allow it to properly fuzz values for FlagField type fields.
+
+import unittest
+
+from scapy.all import *
+
+class TestingFuzzingChanges(unittest.TestCase):
+
+   def test_flag_bounds(self):
+      """
+      This test ensures that the show function fails when a flag value that 
+      exceeds the bounds of a given FlagField is or exceeds the result of
+      2 ^ (FlagField length value). Thus ensuring that the logic used to 
+      generate values for FlagField type fields holds.
+      """
+      tst = IP(flags = 8)
+      with self.assertRaises(IndexError):
+         tst.show()
+      tst = IP(flags = -1)
+      with self.assertRaises(IndexError):
+         tst.show()
+      tst = TCP(flags = 256)
+      with self.assertRaises(IndexError):
+         tst.show()
+      tst = TCP(flags = -1)
+      with self.assertRaises(IndexError):
+         tst.show()
+
+   def test_ip_fuzzing(self):
+      tst = fuzz(IP())
+      self.assertIsNotNone(tst.flags,
+                           msg="Field value not succesfully generated.")
+      self.assertTrue(tst.flags >= 0 and tst.flags < 8, 
+                      msg="Fuzzed value exceeds field boundaries.")
+      # Ensure that fuzzing still works if the flags are preset
+      tst = fuzz(IP(flags=7))
+      self.assertTrue(tst.flags == 7,
+                      msg="Fuzzing overwrote specified flag value.")
+      # Ensure that the original issue was fixed
+      try:
+         fuzz(IP()).show()
+      except TypeError:
+         self.fail("TypeError Exception occurred; original issue not resolved")
+
+   
+   def test_tcp_fuzzing(self):
+      tst = fuzz(TCP())
+      self.assertIsNotNone(tst.flags, 
+                           msg="Field value not succesfully generated.")
+      self.assertTrue(tst.flags >= 0 and tst.flags < 256,
+                      msg="Fuzzed value exceeds field boundaries.")
+      # Ensure that fuzzing still works if the flags are preset
+      tst = fuzz(TCP(flags=255))
+      self.assertTrue(tst.flags == 255,
+                      msg="Fuzzing overwrote specified flag value.")
+      # Ensure that the original issue was fixed
+      try:
+         fuzz(TCP()).show()
+      except TypeError:
+         self.fail("TypeError Exception occurred; original issue not resolved")
+
+   
+
+if __name__ == '__main__':
+   unittest.main()


### PR DESCRIPTION
-Modified the fuzzing function to account for FlagsField type fields and generate an appropriate fuzzed value for the length of the specific flag field (i.e. between 0 and (2 ^ length - 1), 0-7 for IP for example). -Added unit tests to ensure this functionality works and that the original issue was resolved