### PR TITLE
Fix error trying to concat string with byte type

### DIFF
--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -278,7 +278,7 @@ class TCPOptionsField(StrField):
                     onum = TCPOptions[1][oname]
                     ofmt = TCPOptions[0][onum][1]
                     if onum == 5: #SAck
-                        ofmt += b"%iI" % len(oval)
+                        ofmt += "%iI" % len(oval)
                     if ofmt is not None and (type(oval) is not str or "s" in ofmt):
                         if type(oval) is not tuple:
                             oval = (oval,)


### PR DESCRIPTION
This patch fixes an attempt to concat a string object with a byte object. Here's how to reproduce:

```
from scapy.all import *
p = Ether()/IP()/TCP()
p[TCP].options = [('NOP', None), ('NOP', None), ('Timestamp',
(695605763, 695605653)), ('NOP', None), ('NOP', None), ('SAck', (1931354576,
1931354603))]
bytes(p)
```