### PR TITLE
Always close sniff L2socket

### DIFF
--- a/scapy/sendrecv.py
+++ b/scapy/sendrecv.py
@@ -603,8 +603,10 @@ stop_filter: python function applied to each packet to determine
                     break
     except KeyboardInterrupt:
         pass
-    if opened_socket is None:
-        s.close()
+    finally:
+        if opened_socket is None:
+            s.close()
+
     return plist.PacketList(lst,"Sniffed")
 
 


### PR DESCRIPTION
Make sure sniff always closes the L2socket even if it is interrupted by the user.
