### PR TITLE
Correct usec calculation for tsresol other than 6.

### DIFF
--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -733,9 +733,9 @@ class _RawPcapNGReader:
 
     def parse_usec(self, t):
         if self.tsresol & 0b10000000:
-            return t & (1 << self.tsresol) - 1
+            return (t & (1 << self.tsresol) - 1) / pow(10, self.tsresol - 6)
         else:
-            return t % pow(10, self.tsresol)
+            return (t % pow(10, self.tsresol)) / pow(10, self.tsresol - 6)
 
     def parse_options(self, opt):
         buf = opt

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -727,7 +727,7 @@ class _RawPcapNGReader:
     
     def parse_sec(self, t):
         if self.tsresol & 0b10000000:
-            return t >> self.tsresol
+            return t >> (self.tsresol & ~0b10000000)
         else:
             if self.tsresol == 0:
                 return t // pow(10, 6)
@@ -736,7 +736,7 @@ class _RawPcapNGReader:
 
     def parse_usec(self, t):
         if self.tsresol & 0b10000000:            
-            return (t & (1 << self.tsresol) - 1) / pow(2, (self.tsresol & ~0b10000000)) * pow(10, 6)
+            return (t & (1 << (self.tsresol & ~0b10000000)) - 1) / pow(2, (self.tsresol & ~0b10000000)) * pow(10, 6)
         else:
             if self.tsresol == 0:
                 return (t % pow(10, 6))

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -735,8 +735,8 @@ class _RawPcapNGReader:
                 return t // pow(10, self.tsresol)
 
     def parse_usec(self, t):
-        if self.tsresol & 0b10000000:
-            return (t & (1 << self.tsresol) - 1)
+        if self.tsresol & 0b10000000:            
+            return (t & (1 << self.tsresol) - 1) / pow(2, (self.tsresol & ~0b10000000)) * pow(10, 6)
         else:
             if self.tsresol == 0:
                 return (t % pow(10, 6))

--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -729,13 +729,19 @@ class _RawPcapNGReader:
         if self.tsresol & 0b10000000:
             return t >> self.tsresol
         else:
-            return t // pow(10, self.tsresol)
+            if self.tsresol == 0:
+                return t // pow(10, 6)
+            else:
+                return t // pow(10, self.tsresol)
 
     def parse_usec(self, t):
         if self.tsresol & 0b10000000:
-            return (t & (1 << self.tsresol) - 1) / pow(10, self.tsresol - 6)
+            return (t & (1 << self.tsresol) - 1)
         else:
-            return (t % pow(10, self.tsresol)) / pow(10, self.tsresol - 6)
+            if self.tsresol == 0:
+                return (t % pow(10, 6))
+            else:
+                return (t % pow(10, self.tsresol)) / pow(10, self.tsresol - 6)
 
     def parse_options(self, opt):
         buf = opt


### PR DESCRIPTION
parse_usec returns the self.tsresol least significant integers of the passed time t. The result is the interpreted as microseconds. This is only true, if self.tsresol equals 6. If, for example, tsresol is 9, then an 8-digit number is returned that represents a timestamp in nanoseconds, but is then interpreted as microseconds. This happens for every tsresol other than 6.

This pull request normalizes the return value of parse_usec by pow(10, self.tsresol-6), ensuring that the portion of the timestamp smaller than a second is correctly returned in microsecond format. Thus, a nanosecond (tsresol=9) timescale will return 3 decimal spaces, while a millisecond timescale (tsresol=3) will append three zeros.