### PR TITLE
Ignore UTF-8 errors when loading /etc/services

### DIFF
--- a/scapy/data.py
+++ b/scapy/data.py
@@ -106,7 +106,7 @@ def load_services(filename):
     tdct=DADict(_name="%s-tcp"%filename)
     udct=DADict(_name="%s-udp"%filename)
     try:
-        f=open(filename)
+        f=open(filename, errors='ignore')
         for l in f:
             try:
                 shrp = l.find("#")


### PR DESCRIPTION
The /etc/services file contains german umlauts on OpenSuse distributions. These are encoded as 0xf6, which ich the latin1 code for 'ö'.
It should be safe to ignore these invalid characters, as they _should_ (and are in this specific distribution) only be present in the description.