### PR TITLE
Add Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: python
+
+python:
+  - 3.3
+  - 3.4
+  - 3.5
+  - 3.6
+
+install:
+  - pip install cryptography
+
+script:
+  cd test
+  ./run_tests


### PR DESCRIPTION
@phaethon Could you enable Travis builds for Pull Requests?

Currently on Travis it says "Build type disabled via repository...": https://travis-ci.org/phaethon/scapy/requests