### PR TITLE
import_hexcap: migrate to python3.x

### DIFF
--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -7,6 +7,7 @@
 General utility functions.
 """
 
+import codecs
 import os,sys,socket,types
 import random,time
 import gzip,zlib
@@ -980,7 +981,7 @@ def import_hexcap():
     p = ""
     try:
         while 1:
-            l = raw_input().strip()
+            l = input().strip()
             try:
                 p += re_extract_hexcap.match(l).groups()[2]
             except:
@@ -989,8 +990,8 @@ def import_hexcap():
     except EOFError:
         pass
     
-    p = p.replace(" ","")
-    return p.decode("hex")
+    p = p.replace(" ","").encode()
+    return codecs.decode(p, 'hex')
         
 
 


### PR DESCRIPTION
Before decode, input str should be encode.
use codecs.decode(bytes, 'hex')
