### PR TITLE
decode the bytestring before passing to inet_pton()

### DIFF
--- a/scapy/layers/dns.py
+++ b/scapy/layers/dns.py
@@ -225,7 +225,7 @@ class RDataField(StrLenField):
                 s = ret_s
         elif pkt.type == 28: # AAAA
             if s:
-                s = inet_pton(socket.AF_INET6, s)
+                s = inet_pton(socket.AF_INET6, s.decode("utf-8"))
         return s
 
 class RDLenField(Field):


### PR DESCRIPTION
In python3, inet_pton expects a utf string, not a bytestring as argument. Since pkt.rdata is a bytestring, it has to be decode to utf-8 before passing. 

Solves issue #102:
~~~~ ipython
In [1]: an=DNSRR(type='AAAA', rdata='2001::1')

In [2]: bytes(an)
Out[2]: b'\x00\x00\x1c\x00\x01\x00\x00\x00\x00\x00\x10 \x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01'
~~~~