### PR TITLE
Small mistake in dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,12 @@ Support scapy3k inclusion in Kali linux by commenting on the [issue at Kali bug 
 Scapy3k is included in the [Network Security Toolkit] (http://www.networksecuritytoolkit.org/nst/index.html) Release 22. 
 
 Classic scapy has been trying to catch up with the improvements in scapy3k. These features were first implemented in scapy3k and some of them might have been reimplemented in scapy or not:
-* replaced PyCrypto with cryptography.io (thanks to @ThomasFaivre)
 * Windows support without a need for libdnet
 * option to return Networkx graphs instead of image, e.g. for conversations
 * replaced gnuplot with Matplotlib
 * Reading PCAP Next Generation (PCAPNG) files (please, add issues on GitHub for block types and options, which need support. Currently, reading packets only from Enhanced Packet Block)
 * new command tdecode to call tshark decoding on one packet and display results, this is handy for interactive work and debugging
-* some bugs fixed, which are still present in original scapy
+* some bugs fixed
 
 ## Installation
 


### PR DESCRIPTION
That was not accurate, knowing that:

> These features were first implemented

But as you said, from https://github.com/phaethon/scapy/issues/119

> This originally appeared on secdev/scapy

The `matplotlib` comment is a bit borderline too, considering that
https://bitbucket.org/secdev/scapy/pull-requests/92/matplotlib-support/commits
existed in 2015, and that [you added it in `Nov 2015`.](https://github.com/phaethon/scapy/issues/1)