### PR TITLE
Use the provided interface in attach_filter()

### DIFF
--- a/scapy/arch/__init__.py
+++ b/scapy/arch/__init__.py
@@ -75,7 +75,7 @@ if WINDOWS:
 # def get_if_raw_addr(iff):
 # def get_if_list():
 # def get_working_if():
-# def attach_filter(s, filter):
+# def attach_filter(s, bpf_filter, iface):
 # def set_promisc(s,iff,val=1):
 # def read_routes():
 # def get_if(iff,cmd):

--- a/scapy/arch/linux.py
+++ b/scapy/arch/linux.py
@@ -112,8 +112,9 @@ def get_working_if():
         if ifflags & IFF_UP:
             return i
     return LOOPBACK_NAME
-def attach_filter(s, filter):
     # XXX We generate the filter on the interface conf.iface 
+
+def attach_filter(s, bpf_filter, iface):
     # because tcpdump open the "any" interface and ppp interfaces
     # in cooked mode. As we use them in raw mode, the filter will not
     # work... one solution could be to use "any" interface and translate
@@ -122,7 +123,7 @@ def attach_filter(s, filter):
     if not TCPDUMP:
         return
     try:
-        f = os.popen("%s -i %s -ddd -s 1600 '%s'" % (conf.prog.tcpdump,conf.iface,filter))
+        f = os.popen("%s -i %s -ddd -s 1600 '%s'" % (conf.prog.tcpdump, conf.iface if iface is None else iface, bpf_filter))
     except OSError as msg:
         log_interactive.warning("Failed to execute tcpdump: (%s)")
         return
@@ -333,7 +334,7 @@ class L3PacketSocket(SuperSocket):
                 else:
                     filter = "not (%s)" % conf.except_filter
             if filter is not None:
-                attach_filter(self.ins, filter)
+                attach_filter(self.ins, filter, iface)
         _flush_fd(self.ins)
         self.ins.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 2**30)
         self.outs = socket.socket(socket.AF_PACKET, socket.SOCK_RAW, socket.htons(type))
@@ -429,7 +430,7 @@ class L2Socket(SuperSocket):
                 else:
                     filter = "not (%s)" % conf.except_filter
             if filter is not None:
-                attach_filter(self.ins, filter)
+                attach_filter(self.ins, filter, iface)
         self.ins.bind((iface, type))
         _flush_fd(self.ins)
         self.ins.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 2**30)
@@ -476,7 +477,7 @@ class L2ListenSocket(SuperSocket):
                 else:
                     filter = "not (%s)" % conf.except_filter
             if filter is not None:
-                attach_filter(self.ins, filter)
+                attach_filter(self.ins, filter, iface)
         if promisc is None:
             promisc = conf.sniff_promisc
         self.promisc = promisc


### PR DESCRIPTION
It's a copy of this PR: https://github.com/secdev/scapy/pull/43

To fix errors like this:
```
>>> sniff(iface='mon0', store=0, prn=update_time, filter='((wlan addr2 (3c:3e:3d:40:74:66 or c3:ee:fb:3a:10:f0) or wlan addr3 (3c:3e:3d:40:74:66 or c3:ee:fb:3a:10:f0)) and type mgt subtype probe-req) or (wlan addr1 30:3f:60:03:9c:01 and wlan addr3 (3c:3e:3d:40:74:66 or c0:ee:fb:9a:10:f0))')
tcpdump: 'addr2' is only supported on 802.11 with 802.11 headers
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.4/dist-packages/scapy/sendrecv.py", line 574, in sniff
    s = L2socket(type=ETH_P_ALL, *arg, **karg)
  File "/usr/local/lib/python3.4/dist-packages/scapy/arch/linux.py", line 479, in __init__
    attach_filter(self.ins, filter)
  File "/usr/local/lib/python3.4/dist-packages/scapy/arch/linux.py", line 131, in attach_filter
    raise Scapy_Exception("Filter parse error")
scapy.error.Scapy_Exception: Filter parse error
```