### PR TITLE
Fixed conf.route6.__repr__

### DIFF
--- a/scapy/route6.py
+++ b/scapy/route6.py
@@ -50,8 +50,8 @@ class Route6:
             rtlst.append(('%s/%i'% (net,msk), gw, iface, ", ".join(cset)))
 
         #colwidth = map(lambda x: max(map(lambda y: len(y), x)), apply(zip, rtlst))
-        rtlst = zip(rtlst)
-        colwidth = [ max([len(y) for y in x]) for x in rtlst]
+        zipped_rtlst = list(zip(*rtlst))
+        colwidth = [ max([len(y) for y in x]) for x in zipped_rtlst]
         fmt = "  ".join(map(lambda x: "%%-%ds"%x, colwidth))
         rt = "\n".join([ fmt % x for x in rtlst])
 


### PR DESCRIPTION
The original `conf.route6` was printing an empty table. This patch fixes the issue.

Example:

Before:
```
In [1]: conf.route6
Out[1]: 
```

After:
```
Welcome to Scapy (3.0.0) using IPython 5.1.0
In [1]: conf.route6
Out[1]: 
Destination                     Next Hop                    iface  src candidates
2001:xxx:xx:xx::xx:xx/127  ::                          eth0   2001:xx:xx:xx::xx:xx
fe80::/64                       ::                          eth0   fe80::xx:xx:xx
...
```

Side note: this is quite diverging from mainstream scapy, https://github.com/secdev/scapy/blob/master/scapy/route6.py#L55