### PR TITLE
`CAN` layer class/name should be consistent

### DIFF
--- a/scapy/layers/can.py
+++ b/scapy/layers/can.py
@@ -22,7 +22,7 @@ LINKTYPE_CAN_SOCKETCAN = 227  # From pcap spec
 
 
 class CAN(Packet):
-    name = 'SocketCAN'
+    name = 'CAN'
     fields_desc = [
         XIntField('id', 0),
         PadField(FieldLenField('dlc', None, length_of='data', fmt='B'), 4),


### PR DESCRIPTION
At the moment CAN layer `name` is set to be `SocketCAN`, which makes it quite inconsistent:

```python

c = CAN()
c.haslayer('CAN')  # 1
c.name  # 'SocketCAN'
c.getlayer('CAN')  # None
c['CAN']  # IndexError: Layer [CAN] not found
```

Changing the name to simply `CAN` fixes all these issues. I don't see any counter indication?