### PR TITLE
Fixing sprintf regression.uts issue and some more

### DIFF
--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -204,7 +204,7 @@ class NetworkInterfaceDict(UserDict):
         for iface_name in sorted(self.data.keys()):
             dev = self.data[iface_name]
             mac = dev.mac
-            if resolve_mac:
+            if resolve_mac and iface_name != LOOPBACK_NAME:
                 mac = conf.manufdb._resolve_MAC(mac)
             print("%s  %s  %s  %s" % (str(dev.win_index).ljust(5), str(dev.name).ljust(35), str(dev.ip).ljust(15), mac)     )
             

--- a/scapy/arch/windows/__init__.py
+++ b/scapy/arch/windows/__init__.py
@@ -99,6 +99,7 @@ def get_windows_if_list():
             current_interface['mac'] = ':'.join([ j for j in value.split('-')])    
     if current_interface:
         interface_list.append(current_interface)
+    interface_list.append({'name': LOOPBACK_NAME, 'win_index': 1, 'description': LOOPBACK_NAME, 'guid': '', 'mac': ''})
     return interface_list
 
 class NetworkInterface(object):
@@ -111,9 +112,20 @@ class NetworkInterface(object):
         self.pcap_name = None
         self.description = None
         self.data = data
-        if data is not None:
+        if data["name"] == LOOPBACK_NAME:
+            self.init_loopback(data)
+        elif data is not None:
             self.update(data)
-        
+
+    def init_loopback(self, data):
+        """Just initialize the object for our Pseudo Loopback"""
+        self.name = data["name"]
+        self.description = data['description']
+        self.win_index = data['win_index']
+        self.mac = data["mac"]
+        self.guid = data["guid"]
+        self.ip = "127.0.0.1"
+
     def update(self, data):
         """Update info about network interface according to given dnet dictionary"""
         self.name = data["name"]


### PR DESCRIPTION
The sprintf misbehaviour in the regression.uts file happened due to the "Loopback" interface not being "physically" available on Windows.

My changes simulate a loopback interface.

I tested whether routing (conf.route) and interface creation worked (show_interfaces()).
Also successfully performed some pings and arping using scapy.
Short snippet showing the routing table + iface table on Windows:
```Network         Netmask         Gateway         Iface           Output IP
0.0.0.0         0.0.0.0         192.168.192.1   Realtek PCIe GBE Family Controller 192.168.192.86 
127.0.0.0       255.0.0.0       0.0.0.0         lo0             127.0.0.1      
127.0.0.1       255.255.255.255 0.0.0.0         lo0             127.0.0.1      
127.255.255.255 255.255.255.255 0.0.0.0         lo0             127.0.0.1      
192.168.56.0    255.255.255.0   0.0.0.0         VirtualBox Host-Only Ethernet Adapter 192.168.56.1   
192.168.56.1    255.255.255.255 0.0.0.0         VirtualBox Host-Only Ethernet Adapter 192.168.56.1   
192.168.56.255  255.255.255.255 0.0.0.0         VirtualBox Host-Only Ethernet Adapter 192.168.56.1   
192.168.192.0   255.255.255.0   0.0.0.0         Realtek PCIe GBE Family Controller 192.168.192.86 
192.168.192.86  255.255.255.255 0.0.0.0         Realtek PCIe GBE Family Controller 192.168.192.86 
192.168.192.255 255.255.255.255 0.0.0.0         Realtek PCIe GBE Family Controller 192.168.192.86 
224.0.0.0       240.0.0.0       0.0.0.0         lo0             127.0.0.1      
224.0.0.0       240.0.0.0       0.0.0.0         Realtek PCIe GBE Family Controller 192.168.192.86 
224.0.0.0       240.0.0.0       0.0.0.0         VirtualBox Host-Only Ethernet Adapter 192.168.56.1   
255.255.255.255 255.255.255.255 0.0.0.0         lo0             127.0.0.1      
255.255.255.255 255.255.255.255 0.0.0.0         Realtek PCIe GBE Family Controller 192.168.192.86 
255.255.255.255 255.255.255.255 0.0.0.0         VirtualBox Host-Only Ethernet Adapter 192.168.56.1   

INDEX  IFACE                                IP               MAC
15     Bluetooth-Ger„t (PAN)                0.0.0.0          00:26:83:30:D6:92
11     Realtek PCIe GBE Family Controller   192.168.192.86   54:04:A6:69:26:F4
16     VirtualBox Host-Only Ethernet Adapter  192.168.56.1     0A:00:27:00:00:10
1      lo0                                  127.0.0.1        
```

This fixes parts of #199:
- passed DCD84ABB sprintf() function
- passed B4D3A3BB Test of IPv3 class
- passed 564D8829 TFTP Options