### PR TITLE
copy the packet timestamp as part of the copy() method

### DIFF
--- a/scapy/packet.py
+++ b/scapy/packet.py
@@ -160,6 +160,8 @@ class Packet(BasePacket, metaclass = Packet_metaclass):
         clone.post_transforms = self.post_transforms[:]
         clone.__dict__["payload"] = self.payload.copy()
         clone.payload.add_underlayer(clone)
+        clone.time = self.time
+        clone.sent_time = self.sent_time
         return clone
 
     def getfieldval(self, attr):


### PR DESCRIPTION
Previously the copy() method didn't actually copy the packet's time field.