### PR TITLE
Change expected TCP options type from str to bytes.

### DIFF
--- a/scapy/layers/inet.py
+++ b/scapy/layers/inet.py
@@ -369,8 +369,8 @@ class TCPOptionsField(StrField):
                     continue
             else:
                 onum = oname
-                if type(oval) is not str:
-                    warning("option [%i] is not string." % onum)
+                if type(oval) is not bytes:
+                    warning("option [%i] is not of type bytes." % onum)
                     continue
             opt += bytes([(onum), (2 + len(oval))]) + oval
         return opt + b"\x00" * (3 - ((len(opt) + 3) % 4))


### PR DESCRIPTION
I think the expected type of oval should be bytes and checking if it's str is a leftover from Python 2 version. Without this change setting custom TCP options seems impossible because you either hit the continue statement or get an error when appending str to bytes in line 375.