### PR TITLE
Fix regex pattern of IPv6 address.

### DIFF
--- a/scapy/layers/inet6.py
+++ b/scapy/layers/inet6.py
@@ -131,7 +131,7 @@ def getmacbyip6(ip6, chainCC=0):
 class Net6(Gen): # syntax ex. fec0::/126
     """Generate a list of IPv6s from a network address or a name"""
     name = "ipv6"
-    ipaddress = re.compile(r"^([a-fA-F0-9:]+)(/[1]?[0-3]?[0-9])?$")
+    ipaddress = re.compile(r"^([a-fA-F0-9:]+)(/([1]?[0-3]?[0-9]|[0-9]?[0-9]))?$")
 
     def __init__(self, net):
         self.repr = net


### PR DESCRIPTION
In IPv6 class, previous pattern doesn't match fe80::1/64, but this pattern is valid.
So I add new pattern for subnet and this matches fe80::1/64.

This is not error now but wrong, so I fixed.