### PR TITLE
- print() removed in from do_dec()

### DIFF
--- a/scapy/asn1/ber.py
+++ b/scapy/asn1/ber.py
@@ -152,7 +152,6 @@ class BERcodec_Object( metaclass = BERcodec_metaclass):
             context = cls.tag.context
         cls.check_string(s)
         p = (s[0])
-        print(context, type(context))
         if p not in context:
             t = s
             if len(t) > 18:


### PR DESCRIPTION
Print() in `do_dec()` produced a long trail of the following lines when parsing the certificate from TLS Handshake on the stdout:

```
<UNIVERSAL> <class 'scapy.asn1.asn1.ASN1_Class_metaclass'>
<UNIVERSAL> <class 'scapy.asn1.asn1.ASN1_Class_metaclass'>
<UNIVERSAL> <class 'scapy.asn1.asn1.ASN1_Class_metaclass'>
<UNIVERSAL> <class 'scapy.asn1.asn1.ASN1_Class_metaclass'>
<UNIVERSAL> <class 'scapy.asn1.asn1.ASN1_Class_metaclass'>
<UNIVERSAL> <class 'scapy.asn1.asn1.ASN1_Class_metaclass'>
```

