### PR TITLE
Restart select when we see a EINTR

### DIFF
--- a/scapy3k/sendrecv.py
+++ b/scapy3k/sendrecv.py
@@ -6,7 +6,7 @@
 """
 Functions to send and receive packets.
 """
-
+import errno
 import pickle,os,sys,time,subprocess,itertools
 from select import select
 from .data import *
@@ -126,7 +126,12 @@ def sndrcv(pks, pkt, timeout = None, inter = 0, verbose=None, chainCC=0, retry=0
                                 if len(inp) == 0 or pks in inp:
                                     r = pks.nonblock_recv()
                             else:
-                                inp, out, err = select(inmask,[],[], remaintime)
+                                inp = []
+                                try:
+                                    inp, out, err = select(inmask,[],[], remaintime)
+                                except IOError, exc:
+                                    if exc.errno != errno.EINTR:
+                                        raise
                                 if len(inp) == 0:
                                     break
                                 if pks in inp:


### PR DESCRIPTION
This fixes erratic behavior when scapy is run inside of a separate
thread or in another process.
The patch is taken from
https://bitbucket.org/secdev/scapy/issues/473/scapy-sendrecv-selects-eintr-problem-in