### PR TITLE
Fix "Restart select when we see a EINTR" for python3

### DIFF
--- a/scapy3k/sendrecv.py
+++ b/scapy3k/sendrecv.py
@@ -6,7 +6,7 @@
 """
 Functions to send and receive packets.
 """
-
+import errno
 import pickle,os,sys,time,subprocess,itertools
 from select import select
 from .data import *
@@ -126,7 +126,12 @@ def sndrcv(pks, pkt, timeout = None, inter = 0, verbose=None, chainCC=0, retry=0
                                 if len(inp) == 0 or pks in inp:
                                     r = pks.nonblock_recv()
                             else:
-                                inp, out, err = select(inmask,[],[], remaintime)
+                                inp = []
+                                try:
+                                    inp, out, err = select(inmask,[],[], remaintime)
+                                except IOError as exc:
+                                    if exc.errno != errno.EINTR:
+                                        raise
                                 if len(inp) == 0:
                                     break
                                 if pks in inp:

--- a/scapy3k/sendrecv.py
+++ b/scapy3k/sendrecv.py
@@ -6,7 +6,7 @@
 """
 Functions to send and receive packets.
 """
-import errno
+
 import pickle,os,sys,time,subprocess,itertools
 from select import select
 from .data import *
@@ -126,12 +126,7 @@ def sndrcv(pks, pkt, timeout = None, inter = 0, verbose=None, chainCC=0, retry=0
                                 if len(inp) == 0 or pks in inp:
                                     r = pks.nonblock_recv()
                             else:
-                                inp = []
-                                try:
-                                    inp, out, err = select(inmask,[],[], remaintime)
-                                except IOError, exc:
-                                    if exc.errno != errno.EINTR:
-                                        raise
+                                inp, out, err = select(inmask,[],[], remaintime)
                                 if len(inp) == 0:
                                     break
                                 if pks in inp:


### PR DESCRIPTION
The problem was in exception handling for python3 which I missed. Fixing my commit.